### PR TITLE
Using createFragment to prevent unique key warning

### DIFF
--- a/components/NavBarContainer.js
+++ b/components/NavBarContainer.js
@@ -142,7 +142,13 @@ var NavBarContainer = React.createClass({
         )
     }
 
-    var navbarContents = [staticContent, previousContent, currentContent];
+    // Using createFragment to prevent 'Each child in an array should have a unique "key" prop.'
+    // warning message
+    var navbarContents = React.addons.createFragment({
+      "staticContent": staticContent,
+      "previousCountent" : previousContent,
+      "currentContent":currentContent
+    });
 
     return (
       <View style={[styles.navbarContainer, this.props.style]}>


### PR DESCRIPTION
Children components require unique keys to allow the proper redrawing or disposition within the tree in an optimized manner...

Documentation here: http://facebook.github.io/react/docs/multiple-components.html#dynamic-children

> When React reconciles the keyed children, it will ensure that any child with key will be reordered (instead of clobbered) or destroyed (instead of reused).
